### PR TITLE
only look at forecast that made near the start date of the interval

### DIFF
--- a/nowcasting_metrics/metrics/utils.py
+++ b/nowcasting_metrics/metrics/utils.py
@@ -96,11 +96,11 @@ def make_forecast_sub_query(datetime_interval, forecast_horizon_minutes, gsp_id,
     # only load relative new forecasts, stops looking over all forecasts
     # if the start date is 2023-02-01 and horizon is 60 minutes,
     # then we want any forecast that is newer than 2023-02-01 00:00:00 - 60 minutes - 1 day (buffer)
+    # created_utc > start_datetime - forecast_horizon - 1 day
+    # forecast_horizon +  1 day > start_datetime - created_utc
     sub_query_forecast = sub_query_forecast.filter(
-        ForecastSQL.created_utc >
-        datetime_interval.start_datetime_utc
-        - text(f"interval '{forecast_horizon_minutes} minute'")
-        - text(f"interval '1 day'")
+        datetime_interval.start_datetime_utc - ForecastSQL.created_utc
+        < text(f"interval '{forecast_horizon_minutes} minute' + interval '1 day' ")
     )
     sub_query_forecast = sub_query_forecast.filter(
         model.target_time > datetime_interval.start_datetime_utc


### PR DESCRIPTION


# Pull Request

## Description

When doing SQL queries, only look at forecast made within a day of the 
start datetime - forecast hoirzon -(1 day buffer)

## How Has This Been Tested?

CI tests
- [ ] Yes

## Checklist:

- [ ] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked my code and corrected any misspellings
