### PR TITLE
dont commit to database after make each metric, only commit at the end

### DIFF
--- a/nowcasting_metrics/utils.py
+++ b/nowcasting_metrics/utils.py
@@ -79,4 +79,3 @@ def save_metric_value_to_database(
             metric_value_sql.p_level = plevel
 
         session.add(metric_value_sql)
-        session.commit()


### PR DESCRIPTION
# Pull Request

## Description

Dont commit to session every time a metric is made, only do this at the end. This makes things run much faster

## How Has This Been Tested?

- CI tests

## Checklist:

- [x] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked my code and corrected any misspellings
